### PR TITLE
Fix custom font not applying

### DIFF
--- a/src/UIComponents.js
+++ b/src/UIComponents.js
@@ -71,7 +71,6 @@ const Label = Styled(Animated.Text)`
 	fontSize: ${(p) =>
     p.whenInactiveShow == "both" || p.whenActiveShow == "both" ? "14" : "17"};
 	color: ${(p) => p.activeColor};
-	font-weight: bold;
 	margin-left: ${(p) =>
     p.whenActiveShow == "both" || p.whenInactiveShow == "both" ? 8 : 0};
 `;


### PR DESCRIPTION
Fix custom fonts not applying  
Instead of making the tab label bold as default, Let user provide `fontWeight: 'bold'` to there labelStyle