### PR TITLE
fix: Typos on the naming of the appearance prop

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,21 +1,21 @@
-# Changelog 
+# Changelog
 - _February 6 20201_
   - Fixed #71
   - Added new changelog to separate file `Changelog.md`
 - _January 29 2021_
-  - Typescript support 👀 including custom enums for some of the appearence properties
+  - Typescript support 👀 including custom enums for some of the appearance properties
   - Added Rollup as a module bundler 
   - Fixed Invalid Hook Call bug #62
   - Fixed `have your wrapper your NavigationContainer` bug. Please update to react-navigation/native 5.9.0, stack 5.13.0, bottom-tabs 5.11.3
 - _October 11 2020_
   - Updated react-navigation dependencies in example folder to latest
   - Fixed useScrollToTop bug
-  - Fix Tab bar overlays scrollview content
-  - Added new config for icon button layour/orientation
+  - Fix Tab bar overlays ScrollView content
+  - Added new config for icon button layout/orientation
 - _September 27 2020_
   - Updated example to rn 0.63
-  - Fixed issue #37 where screens would re-render on every tab change. Also added the lazy option found in the default react navigation tabbar
-  - Fixed default props errors #34 and #35. The component doesn't require any appearence options to work. It will use default style. See docs how to change.
+  - Fixed issue #37 where screens would re-render on every tab change. Also added the lazy option found in the default react navigation TabBar
+  - Fixed default props errors #34 and #35. The component doesn't require any appearance options to work. It will use default style. See docs how to change.
   - Fixed issue with screen listeners #38 (you can now prevent default)
   - Fixed small ui glitches
 - _April 19 2020_
@@ -24,7 +24,7 @@
 - _March 11 2020_
 - _June 25 2020_
   - Upgrade to v3.0
-  - Add more customisations including, floating style, icon configs, label configs, and more.
+  - Add more customizations including, floating style, icon configs, label configs, and more.
   - Fixed issues with changing screen orientation
   - Fixed animation when provided initial screen
   - Improved code quality, refactoring

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 # react-native-animated-nav-tab-bar
 
 <img src="https://i.imgur.com/IfQh9UQ.png" width="150" height="150"/>
-<p>A simple and customisable React Native component that implements an animated bottom tab bar for React Navigation v5.</p>
+<p>A simple and customizable React Native component that implements an animated bottom tab bar for React Navigation v5.</p>
 
 - 60FPS
 - Support for iPhoneX
-- Lots of customisation
+- Lots of customization
 - Bottom Tab Bar Floating style
 
 ## 📆 Updates / Changelog
@@ -20,7 +20,7 @@
 
 <img src="https://i.imgur.com/lRG92ds.gif" width="300">
 
-## Customisation Preview
+## Customization Preview
 
 <div style="display:flex;">config1.png
 <img src="https://github.com/torgeadelin/react-native-animated-nav-tab-bar/blob/master/demo_images/demo1.png?raw=true" width="300">
@@ -28,7 +28,7 @@
 <img src="https://github.com/torgeadelin/react-native-animated-nav-tab-bar/blob/master/demo_images/demo3.png?raw=true" width="300">
 </div>
 
-## Other possible Customisations
+## Other possible Customizations
 
 ### Tab Bar Icons
 
@@ -90,12 +90,12 @@ import {
   DotSize, // optional
   TabElementDisplayOptions, // optional
   TabButtonLayout, // optional
-  IAppearenceOptions // optional
+  IAppearanceOptions // optional
 } from 'react-native-animated-nav-tab-bar'
 
 ```
 
-#### Initialise
+#### Initialize
 
 Then create a navigator using the navigation builder that you imported, and create your navigation! Look at the example below.
 
@@ -164,30 +164,30 @@ export default () =>
 
 ## Documentation
 
-The navigation component takes two main props which help you customise your navigation. `tabBarOptions` is the default prop from React Navigation which you can use to specify different tint colors and more (see available options below). for all the details. The second prop is `appearence`. Here you'll be able to adjust several properties of the tab bar as you wish. See the available properties above.
+The navigation component takes two main props which help you customize your navigation. `tabBarOptions` is the default prop from React Navigation which you can use to specify different tint colors and more (see available options below). for all the details. The second prop is `appearance`. Here you'll be able to adjust several properties of the tab bar as you wish. See the available properties above.
 
 - **tabBarOptions**
 
   - ✅`activeTintColor` - Label and icon color of the active tab item.
   - ✅`inactiveTintColor` - Label and icon color of the inactive tab item.
   - ✅`activeBackgroundColor` - Background color of the active tab item.
-  - ✅`tabStyle` - Style object for the tab wrapper (**Note!** it overrides the properties in `appearence` prop (see below).
+  - ✅`tabStyle` - Style object for the tab wrapper (**Note!** it overrides the properties in `appearance` prop (see below).
   - ✅`labelStyle` - Style object for the tab label text.
 
-- **appearence**
+- **appearance**
 
   - ✅`topPadding` (default: 20) - Space between the tab button and the wrapper (top)
   - ✅`horizontalPadding` (default: 20) - Vertical space between for the tab buttons
-  - ✅`tabBarBackground` (default: "white") - Backgorund color for the wrapper that contains the navigation tabs
+  - ✅`tabBarBackground` (default: "white") - Background color for the wrapper that contains the navigation tabs
   - ✅`shadow` (default: true) - If set to true, the wrapper has a light shadow
 
   - ✅`activeTabBackgrounds` - Array of hex colours for the background of each tab when active. (if not specified, falls back to the `activeBackgroundColor` from `tabBarOptions`)
   - ✅`activeColors` - Array of hex colours for the tint of each tab when active. (if not specified, falls back to the `activeTintColor` from `tabBarOptions`)
 
   - ✅`floating` (default: false) - If set to true, the nav bar will float on top of the current screen. Look at examples above.
-  - ✅`whenActiveShow` (default: "both") Configure the appearence of the active tab. Available values `both`, `label-only`, `icon-only`.
-  - ✅`whenInactiveShow` (default: "icon-only") Configure the appearence of the inactive tabs. Available values `both`, `label-only`, `icon-only`.
-  - ✅`tabButtonLayout` (default: "horizontal") Congifure the layour of the tab button. Available values `vertical`, `horizontal`.
+  - ✅`whenActiveShow` (default: "both") Configure the appearance of the active tab. Available values `both`, `label-only`, `icon-only`.
+  - ✅`whenInactiveShow` (default: "icon-only") Configure the appearance of the inactive tabs. Available values `both`, `label-only`, `icon-only`.
+  - ✅`tabButtonLayout` (default: "horizontal") Configure the layout of the tab button. Available values `vertical`, `horizontal`.
 
   - ✅`dotCornerRadius` (default: 100) Corner radius for the active background / dot.
   - ✅`dotSize` (default: "medium") Size of dot for the active tab. Available values `small`, `medium`, `large`.
@@ -196,7 +196,7 @@ The navigation component takes two main props which help you customise your navi
 
 ## Troubleshooting
 
-- My tab doesn't reflect the `tabStyle` object when I set `paddingTop`. **Solution**: You must provide the same value for `paddingTop` in both `tabStyle` object and `topPadding` property from `appearence`. This is due to the fact that the dot / active background uses position absolute, and the parent's padding top does not affect it.
+- My tab doesn't reflect the `tabStyle` object when I set `paddingTop`. **Solution**: You must provide the same value for `paddingTop` in both `tabStyle` object and `topPadding` property from `appearance`. This is due to the fact that the dot / active background uses position absolute, and the parent's padding top does not affect it.
 
 ## Contributing
 

--- a/example-typescript/navigation/AppNavigation.tsx
+++ b/example-typescript/navigation/AppNavigation.tsx
@@ -1,7 +1,8 @@
-import React from 'react'
-import { Text, TouchableOpacity, Image } from 'react-native'
 import { AnimatedTabBarNavigator, DotSize, TabElementDisplayOptions } from 'react-native-animated-nav-tab-bar'
+import { Image, Text, TouchableOpacity } from 'react-native'
+
 import Icon from 'react-native-vector-icons/Feather'
+import React from 'react'
 import styled from 'styled-components/native'
 
 const Tabs = AnimatedTabBarNavigator()
@@ -72,7 +73,7 @@ export default () => (
 			inactiveTintColor: "#223322",
 			activeBackgroundColor: "red"
 		}}
-		appearence={{
+		appearance={{
 			shadow: true,
 			floating: true,
 			whenActiveShow: TabElementDisplayOptions.ICON_ONLY,

--- a/index.ts
+++ b/index.ts
@@ -1,12 +1,12 @@
+import { DotSize, IAppearanceOptions, TabButtonLayout, TabElementDisplayOptions } from './src/types';
 
 import AnimatedTabBarNavigator from './src/AnimatedTabBarNavigator';
-import { TabElementDisplayOptions, DotSize, TabButtonLayout, IAppearenceOptions } from './src/types';
 
 export {
     AnimatedTabBarNavigator,
     TabElementDisplayOptions,
     DotSize,
     TabButtonLayout,
-    IAppearenceOptions
+    IAppearanceOptions
 };
 

--- a/src/AnimatedTabBarNavigator.tsx
+++ b/src/AnimatedTabBarNavigator.tsx
@@ -1,13 +1,15 @@
 import * as React from "react";
-import {
-  useNavigationBuilder,
-  createNavigatorFactory,
-  TabRouter,
-} from "@react-navigation/native";
-import TabBarElement from "./TabBarElement";
-import { DotSize, IAppearenceOptions, TabButtonLayout, TabElementDisplayOptions } from './types';
 
-const defaultAppearence: IAppearenceOptions = {
+import { DotSize, IAppearanceOptions, TabButtonLayout, TabElementDisplayOptions } from './types';
+import {
+  TabRouter,
+  createNavigatorFactory,
+  useNavigationBuilder,
+} from "@react-navigation/native";
+
+import TabBarElement from "./TabBarElement";
+
+const defaultAppearance: IAppearanceOptions = {
   topPadding: 10,
   bottomPadding: 10,
   horizontalPadding: 10,
@@ -38,7 +40,7 @@ interface IBottomTabNavigatorProps {
   children: React.ReactNode;
   screenOptions?: any;
   tabBarOptions?: any;
-  appearence: Partial<IAppearenceOptions>;  
+  appearance: Partial<IAppearanceOptions>;  
 }
 
 const BottomTabNavigator = ({
@@ -47,7 +49,7 @@ const BottomTabNavigator = ({
   children,
   screenOptions,
   tabBarOptions,
-  appearence,
+  appearance,
   ...rest
 }: IBottomTabNavigatorProps) => {
   
@@ -58,9 +60,9 @@ const BottomTabNavigator = ({
     screenOptions,
   });
 
-  const finalAppearence: IAppearenceOptions = {
-    ...defaultAppearence,
-    ...appearence
+  const finalAppearance: IAppearanceOptions = {
+    ...defaultAppearance,
+    ...appearance
   }
 
   const finalTabBarOptions = {
@@ -75,7 +77,7 @@ const BottomTabNavigator = ({
       navigation={navigation}
       descriptors={descriptors}
       tabBarOptions={finalTabBarOptions}
-      appearence={finalAppearence}
+      appearance={finalAppearance}
     />
   );
 }

--- a/src/TabBarElement.tsx
+++ b/src/TabBarElement.tsx
@@ -1,31 +1,30 @@
-import React, { useState, useEffect } from "react";
-import { ScreenContainer } from "react-native-screens";
-
 // UI Components imports
 import {
   Animated,
   BackHandler,
-  View,
   Dimensions,
-  StyleSheet,
   Platform,
+  StyleSheet,
+  View,
 } from "react-native";
 import {
-  TabButton,
   BottomTabBarWrapper,
   Dot,
   Label,
+  TabButton,
 } from "./UIComponents";
-import ResourceSavingScene from "./ResourceSavingScene";
-import { CommonActions, Descriptor, NavigationState, PartialState, TabNavigationState, Route } from "@react-navigation/native";
-import { IAppearenceOptions, TabElementDisplayOptions } from "./types";
+import { CommonActions, Descriptor, NavigationState, PartialState, Route, TabNavigationState } from "@react-navigation/native";
+import { IAppearanceOptions, TabElementDisplayOptions } from "./types";
+import React, { useEffect, useState } from "react";
 
+import ResourceSavingScene from "./ResourceSavingScene";
+import { ScreenContainer } from "react-native-screens";
 
 interface TabBarElementProps {
   state: TabNavigationState<Record<string, object | undefined>>;
   navigation: any;
   descriptors: Record<string, Descriptor<Record<string, object | undefined>, string, TabNavigationState<Record<string, object | undefined>>, any, {}>>;
-  appearence: IAppearenceOptions;
+  appearance: IAppearanceOptions;
   tabBarOptions?: any;
   lazy?: boolean;
 }
@@ -38,7 +37,7 @@ interface TabBarElementProps {
  * @param state Navigation state
  * @param navigation Navigation object
  * @param descriptors
- * @param appearence Object with appearence configurations (see readme)
+ * @param appearance Object with appearance configurations (see readme)
  * @param rest
  *
  * @return function that creates the custom tab bar
@@ -47,7 +46,7 @@ export default ({
   state,
   navigation,
   descriptors,
-  appearence,
+  appearance,
   tabBarOptions,
   lazy,
 }: TabBarElementProps) => {
@@ -66,7 +65,7 @@ export default ({
     dotSize,
     shadow,
     tabButtonLayout,
-  } = appearence;
+  } = appearance;
 
   const {
     activeTintColor,

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -17,7 +17,7 @@ export enum TabElementDisplayOptions {
     HORIZONTAL = 'horizontal'
   }
   
-  export interface IAppearenceOptions {
+  export interface IAppearanceOptions {
     topPadding: number;
     bottomPadding: number;
     horizontalPadding: number;


### PR DESCRIPTION
This PR solves a naming typo with the appearance prop.

Before this change, it was **appearence** instead of _appearance_
It also fixes some other typos on the README.md

⚠️ DISCLAIMER: This is a breaking change as the appearance prop changed.

PROP AND TYPES CHANGED:
appearence -> appearance
IAppearenceOptions -> IAppearanceOptions
