### PR TITLE
feat: Update the new way to remove a listener from BackHandler

### DIFF
--- a/src/TabBarElement.tsx
+++ b/src/TabBarElement.tsx
@@ -13,6 +13,7 @@ import {
   BackHandler,
   Dimensions,
   I18nManager,
+  NativeEventSubscription,
   Platform,
   StyleSheet,
   View,
@@ -156,14 +157,15 @@ export default ({
     animation(animatedPos).start(() => {
       updatePrevPos();
     });
+    let backHandlerSubscription:NativeEventSubscription|undefined;
 
     if (Platform.OS === "android") {
-      BackHandler.addEventListener("hardwareBackPress", handleBackPress);
+      backHandlerSubscription = BackHandler.addEventListener("hardwareBackPress", handleBackPress);
     }
 
     return () => {
       if (Platform.OS === "android") {
-        BackHandler.removeEventListener("hardwareBackPress", handleBackPress);
+        backHandlerSubscription?.remove();
       }
     };
   }, []);


### PR DESCRIPTION
I've been working with version 0.77 of react-native, and the component reports an error when removing the BackHandler listener.
To allow the package to remain usable in newer versions of react-native, I've taken care to fix this issue. This improvement has been available since version 0.65.