### PR TITLE
Fix/140 ensure active tab background color appears behind tab content on iOS and Android

### DIFF
--- a/src/TabBarElement.tsx
+++ b/src/TabBarElement.tsx
@@ -26,10 +26,7 @@ import { BottomTabBarWrapper, Dot, Label, TabButton } from "./UIComponents";
 interface TabBarElementProps {
   state: TabNavigationState<Record<string, object | undefined>>;
   navigation: any;
-  descriptors: Record<
-    string,
-    Descriptor<any, any, any>
-  >;
+  descriptors: Record<string, Descriptor<any, any, any>>;
   appearance: IAppearanceOptions;
   tabBarOptions?: any;
   lazy?: boolean;
@@ -157,10 +154,13 @@ export default ({
     animation(animatedPos).start(() => {
       updatePrevPos();
     });
-    let backHandlerSubscription:NativeEventSubscription|undefined;
+    let backHandlerSubscription: NativeEventSubscription | undefined;
 
     if (Platform.OS === "android") {
-      backHandlerSubscription = BackHandler.addEventListener("hardwareBackPress", handleBackPress);
+      backHandlerSubscription = BackHandler.addEventListener(
+        "hardwareBackPress",
+        handleBackPress
+      );
     }
 
     return () => {
@@ -444,8 +444,7 @@ export default ({
             tabBarBackground={tabBarBackground}
             shadow={shadow}
           >
-            {state.routes.map(createTab)}
-            {/* Animated Dot / Background */}
+            {/* Animated Dot / Background - render first so it's behind the tab buttons */}
             <Dot
               dotCornerRadius={dotCornerRadius}
               topPadding={topPadding}
@@ -468,6 +467,7 @@ export default ({
               width={width}
               height={height}
             />
+            {state.routes.map(createTab)}
           </BottomTabBarWrapper>
         </View>
       )}

--- a/src/UIComponents.ts
+++ b/src/UIComponents.ts
@@ -37,8 +37,8 @@ const BottomTabBarWrapper = Styled.View<IBottomTabBarWrapper>`
     p.floating
       ? p.bottomPadding
       : isIphoneX()
-        ? BOTTOM_PADDING_IPHONE_X + p.bottomPadding
-        : p.bottomPadding}px;
+      ? BOTTOM_PADDING_IPHONE_X + p.bottomPadding
+      : p.bottomPadding}px;
   padding-top: ${(p) => p.topPadding}px;
   padding-horizontal: ${(p) => p.horizontalPadding}px;
   background-color: ${(p) => p.tabBarBackground};
@@ -66,16 +66,14 @@ interface ITabButton {
   dotSize: DotSize;
 }
 
-
 const TabButton = Styled.TouchableOpacity<ITabButton>`
 	flex: 1;
 	flex-direction: ${(p) =>
     p.tabButtonLayout == TabButtonLayout.VERTICAL
       ? "column"
       : p.tabButtonLayout == TabButtonLayout.HORIZONTAL
-        ? "row"
-        : "row"
-  };
+      ? "row"
+      : "row"};
 	justify-content: center;
 	align-items: center;
 	border-radius: 100px;
@@ -93,11 +91,15 @@ interface ILabelProps {
 
 const Label = Styled(Animated.Text)<ILabelProps>`
 	fontSize: ${(p) =>
-    p.whenInactiveShow == TabElementDisplayOptions.BOTH || p.whenActiveShow == TabElementDisplayOptions.BOTH ? "14" : "17"}px;
+    p.whenInactiveShow == TabElementDisplayOptions.BOTH ||
+    p.whenActiveShow == TabElementDisplayOptions.BOTH
+      ? "14"
+      : "17"}px;
 	color: ${(p) => p.activeColor};
 	margin-left: ${(p) =>
-    (p.whenActiveShow == TabElementDisplayOptions.BOTH || p.whenInactiveShow == TabElementDisplayOptions.BOTH) &&
-      p.tabButtonLayout == TabButtonLayout.HORIZONTAL
+    (p.whenActiveShow == TabElementDisplayOptions.BOTH ||
+      p.whenInactiveShow == TabElementDisplayOptions.BOTH) &&
+    p.tabButtonLayout == TabButtonLayout.HORIZONTAL
       ? 8
       : 0}px;
 `;
@@ -117,7 +119,6 @@ const Dot = Styled(Animated.View)<IDotProps>`
 	height: ${(p) => p.height}px;
 	border-radius: ${(p) => p.dotCornerRadius}px;
 	background-color: ${(p) => p.activeTabBackground};
-	z-index: -1;
 `;
 
 const SHADOW = css`


### PR DESCRIPTION
### Problem
Previously, the active tab background (Dot) was either not visible or was overlaying the tab icon and label on iOS, due to stacking order and z-index issues. This caused the `activeBackgroundColor` to not display as intended behind the active tab content.

### Solution
- The Dot component (active tab background) is now rendered before the tab buttons in the component tree, ensuring it appears behind the icons and labels on both iOS and Android.
- The z-index property was removed from the Dot styled-component, as the correct stacking is now achieved by render order.
- This resolves the issue where the active tab background color was not visible or was overlaying tab content on iOS, while maintaining correct behavior on Android.

### Testing
- Verified that the active tab background color now appears behind the tab icon and label on both iOS and Android.
- No regression observed in tab bar behavior or appearance.

---

Closes #140 (if you want to reference the related GitHub issue).